### PR TITLE
update RFC-2895

### DIFF
--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -276,7 +276,7 @@ Error:
 
 Mission accomplished! The error trait gave us everything we needed to build
 error reports enriched by context relevant to our application. This same
-pattern can be implement many error reporting patterns, such as including help
+pattern can implement many error reporting patterns, such as including help
 text, spans, http status codes, or backtraces in errors which are still
 accessible after the error has been converted to a `dyn Error`.
 

--- a/text/0000-dyn-error-generic-member-access.md
+++ b/text/0000-dyn-error-generic-member-access.md
@@ -154,11 +154,13 @@ The `Error` trait accomplishes this by providing a set of methods for accessing
 members of `dyn Error` trait objects. It requires that types implement the
 `Display` trait, which acts as the interface to the main member, the error
 message itself.  It provides the `source` function for accessing `dyn Error`
-members, which typically represent the current error's cause. Via
-`#![feature(backtrace)]` it provides the `backtrace` function, for accessing a
-`Backtrace` of the state of the stack when an error was created. For all other
-forms of context relevant to an error report, the `Error` trait provides the
-`context`, context_ref`, and `provide_context` functions.
+members, which typically represent the current error's cause.
+
+For all other forms of context relevant to an error report, the `Error` trait
+offers the `provide_context` method. The report renderer indirectly calls
+`provide_context` for any `Error` type that implements it using standard
+library methods on `dyn Error` itself: `<dyn Error>.request_ref` and `<dyn
+Error>.request_value`.
 
 As an example of how to use this interface to construct an error report, let’s
 explore how one could implement an error reporting type. In this example, our
@@ -243,7 +245,7 @@ impl fmt::Debug for ErrorReporter {
 
         for (ind, error) in errors.enumerate() {
             writeln!(fmt, "    {}: {}", ind, error)?;
-            if let Some(location) = error.context_ref::<Location>() {
+            if let Some(location) = error.request_ref::<Location>() {
                 writeln!(fmt, "        at {}:{}", location.file, location.line)?;
             }
         }


### PR DESCRIPTION
This PR does three things:

* it removes a reference to the `backtrace` unstable feature (which I believe has been stabilized) and the defunct `backtrace` method on `Error`
* it removes a big chunk of the old proof of concept code, references the current unstable implementation in the standard library, and adds some of the public-facing API snippets with explanation as to how they are intended to be used
* adds a reference to RFC 3192 in the "prior art" section
  * considered "prior" because I am proposing that `provide_any` and `error_generic_member_access` [be merged](https://github.com/rust-lang/rust/issues/96024#issuecomment-1629794600)

One thing I think is still missing from my changes to this RFC is a bit more detail about how `<dyn Error>.request_ref` and `<dyn Error>.request_value` are implemented in terms of the new private type `core::any::TaggedOption` and module `core::any::tags`. I think that's appropriate because of the documentation on the reference-level explanation section: https://github.com/rust-lang/rfcs/blob/master/0000-template.md#reference-level-explanation

> Its interaction with other features is clear.
> It is reasonably clear how the feature would be implemented.

@yaahc I think your offer to sync up and discuss this further would help me flesh this section out, unless you don't think it's necessary to go into any further detail.